### PR TITLE
Fix misleading comment on parameters to `open` function

### DIFF
--- a/script/pageload/functions.js
+++ b/script/pageload/functions.js
@@ -16,7 +16,7 @@ var insertAfter = function(newNode, referenceNode) {
 getAllBounties = function(callback){
   var bounties_api_url = 'https://gitcoin.co/api/v0.1/bounties/?idx_status=open&network=mainnet&order_by=-web3_created';
   var xmlHttp = new XMLHttpRequest();
-  xmlHttp.open( "GET", bounties_api_url, true ); // false for asynchronous request
+  xmlHttp.open( "GET", bounties_api_url, true ); // true for asynchronous request
   xmlHttp.onload = function (e) {
     if (xmlHttp.readyState === 4) {
       if (xmlHttp.status === 200) {


### PR DESCRIPTION
false for asynchronous request -> **_true_** for asynchronous request

The issue seems to have been introduced in [this commit](https://github.com/gitcoinco/browser-extension/commit/03307f8b8c46fdc4679dcb882d047e8e4b55c4a0#diff-feeffd89cc7e98293fdfcfa54487ffb3R19) where the argument was updated but not the comment.