### PR TITLE
add basic support for firefox extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # production
 /build
+/web-ext-artifacts
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Extension allows users to find new & interesting work, right where you work, on github.com.
 
-# Gitcoin
+# Gitcoin Web Extension
 
 Gitcoin pushes Open Source Forward.  Learn more at [https://gitcoin.co](https://gitcoin.co)
 
@@ -60,6 +60,14 @@ const DEVELOPMENT = true
 That will use mocked json file in `/public/mock.gitcoin.co.json`.
 
 Then debugging the popup page via `yarn start`.
+
+## Web extention lint
+
+run web extention lint via
+
+```
+npm run extlint
+```
 
 ## Test
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "private": true,
   "dependencies": {
     "bootstrap": "^4.1.1",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "web-ext": "^2.7.0"
   },
   "devDependencies": {
     "jest-localstorage-mock": "^2.2.0",
@@ -15,8 +16,9 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "prebuild": "",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "extlint": "npm run build && npx web-ext lint -s build/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start": "react-scripts start",
     "prebuild": "",
     "build": "react-scripts build",
+    "buildFirefox": "npm run build && npx web-ext build -s build/",
     "test": "react-scripts test --env=jsdom",
     "extlint": "npm run build && npx web-ext lint -s build/"
   }

--- a/public/script/background.js
+++ b/public/script/background.js
@@ -1,13 +1,15 @@
-chrome.extension.onMessage.addListener(function(message, sender) {
+var browser = typeof browser !== 'undefined' ? browser : chrome;
+
+browser.runtime.onMessage.addListener(function(message, sender) {
     if(typeof message == 'string'){
-      chrome.browserAction.setBadgeBackgroundColor({
+      browser.browserAction.setBadgeBackgroundColor({
           color: '#15003e'
       });
-      chrome.browserAction.setBadgeText({text: message});
+      browser.browserAction.setBadgeText({text: message});
     }
 });
 
-chrome.runtime.onMessage.addListener(
+browser.runtime.onMessage.addListener(
     function(request, sender, sendResponse){
         for (var key in request) {
          localStorage[key] = request[key];

--- a/public/script/pageload/body.js
+++ b/public/script/pageload/body.js
@@ -1,5 +1,3 @@
-
-
 //injects various information on the page
 var body = function(url) {
     var isOnGitHubcom = url.indexOf('://github.com') !== -1;

--- a/public/script/pageload/callbacks.js
+++ b/public/script/pageload/callbacks.js
@@ -1,9 +1,10 @@
+var browser = typeof browser !== 'undefined' ? browser : chrome;
 
 //inject the ability to respond
 injectScript('function respond_to_ext(type, response) { window.postMessage({ type: type, text: response}, "*"); }');
 
 //inject listening callbacks
-callbacks = [
+const callbacks = [
     function(event){
         //console.log("Stored " + event.data.type + ', ' + event.data.text);
     },
@@ -13,7 +14,7 @@ callbacks = [
     function(event){
         var msg = {};
         msg[event.data.type]=event.data.text;
-        chrome.runtime.sendMessage(msg);
+        browser.runtime.sendMessage(msg);
     },
     function(event){
         if(event.data.type == 'bountyDetails'){

--- a/public/script/pageload/functions.js
+++ b/public/script/pageload/functions.js
@@ -1,3 +1,5 @@
+var browser = typeof browser !== 'undefined' ? browser : chrome;
+
 //function defs
 var injectScript = function(script) {
     var elt = document.createElement("script");
@@ -6,7 +8,7 @@ var injectScript = function(script) {
 }
 
 var setThumbnail = function(text){
-  chrome.extension.sendMessage(text);
+  browser.runtime.sendMessage(text);
 };
 
 var insertAfter = function(newNode, referenceNode) {


### PR DESCRIPTION
can do web extention lint via `npm run extlint`

can build firefox extention via `npm run buildFirefox` & load the package through https://developer.mozilla.org/en-US/docs/Tools/about%3Adebugging#Enabling_add-on_debugging

It's not ready for publish to firefox addon marketplace yet (at last time firefox reviewer require us to remove the usage of innerHTML)